### PR TITLE
Support different transifex configurations

### DIFF
--- a/src/CyberSpectrum/Command/CommandBase.php
+++ b/src/CyberSpectrum/Command/CommandBase.php
@@ -25,6 +25,8 @@ abstract class CommandBase extends Command
 
 	protected $languages;
 
+    protected $transifexconfig;
+
 	protected function configure()
 	{
 		parent::configure();
@@ -34,6 +36,7 @@ abstract class CommandBase extends Command
 		$this->addOption('projectname', 'p', InputOption::VALUE_OPTIONAL, 'The project name, if empty it will get read from the composer.json.', null);
 		$this->addOption('prefix', null, InputOption::VALUE_OPTIONAL, 'The prefix for all language files, if empty it will get read from the composer.json.', null);
 		$this->addOption('base-language', 'b', InputOption::VALUE_OPTIONAL, 'The base language to use.', 'en');
+		$this->addOption('transifex-config', 't', InputOption::VALUE_OPTIONAL, 'The transifex configuration to take.', 'transifex');
 
 		$this->addArgument('languages', InputArgument::OPTIONAL, 'Languages to process as comma delimited list or "all" for all languages.', 'all');
 	}
@@ -115,6 +118,11 @@ abstract class CommandBase extends Command
 		return $value;
 	}
 
+    protected function getTransifexConfigValue($name)
+    {
+        return $this->getConfigValue('/' . $this->transifexconfig . $name);
+    }
+
 	protected function checkValidSlug($slug)
 	{
 		if (preg_match_all('#^([a-z,A-Z,0-9,\-,_]*)(.+)?$#', $slug, $matches)
@@ -162,18 +170,20 @@ abstract class CommandBase extends Command
 
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
-		$this->project      = $input->getOption('projectname');
-		$this->prefix       = $input->getOption('prefix');
-		$this->txlang       = $input->getOption('xliff');
-		$this->ctolang      = $input->getOption('contao');
-		$this->baselanguage = $input->getOption('base-language');
+		$this->project          = $input->getOption('projectname');
+		$this->prefix           = $input->getOption('prefix');
+		$this->txlang           = $input->getOption('xliff');
+		$this->ctolang          = $input->getOption('contao');
+		$this->baselanguage     = $input->getOption('base-language');
+		$this->transifexconfig  = $input->getOption('transifex-config');
 
 		$this->checkValidSlug($this->project);
 		$this->checkValidSlug($this->prefix);
 
 		if (!$this->project)
 		{
-			$this->project = $this->getConfigValue('/transifex/project');
+			$this->project = $this->getTransifexConfigValue('/project');
+
 			if (!$this->project)
 			{
 				throw new \RuntimeException('Error: unable to determine transifex project name.');
@@ -184,7 +194,7 @@ abstract class CommandBase extends Command
 
 		if (!$this->prefix)
 		{
-			$this->prefix = $this->getConfigValue('/transifex/prefix');
+			$this->prefix = $this->getTransifexConfigValue('/prefix');
 
 			if (!$this->prefix)
 			{
@@ -195,7 +205,7 @@ abstract class CommandBase extends Command
 
 		if (!$this->txlang)
 		{
-			$this->txlang = $this->getConfigValue('/transifex/languages_tx');
+			$this->txlang = $this->getTransifexConfigValue('/languages_tx');
 
 			if (!$this->txlang)
 			{
@@ -206,7 +216,7 @@ abstract class CommandBase extends Command
 
 		if (!$this->ctolang)
 		{
-			$this->ctolang = $this->getConfigValue('/transifex/languages_cto');
+			$this->ctolang = $this->getTransifexConfigValue('/languages_cto');
 
 			if (!$this->ctolang)
 			{

--- a/src/CyberSpectrum/Command/Transifex/TransifexBase.php
+++ b/src/CyberSpectrum/Command/Transifex/TransifexBase.php
@@ -66,7 +66,7 @@ class TransifexBase extends CommandBase
 		$user = $input->getOption('user');
 		if (!$user)
 		{
-			if ($user = $this->getConfigValue('/transifex/user'))
+			if ($user = $this->getTransifexConfigValue('/user'))
 			{
 				$this->writelnVerbose($output, 'Using transifex user specified in config.');
 			}
@@ -95,7 +95,7 @@ class TransifexBase extends CommandBase
 
 		if (!$pass)
 		{
-			if ($pass = $this->getConfigValue('/transifex/pass'))
+			if ($pass = $this->getTransifexConfigValue('/pass'))
 			{
 				$this->writelnVerbose($output, 'Using transifex password specified in config.');
 			}

--- a/src/CyberSpectrum/JsonConfig.php
+++ b/src/CyberSpectrum/JsonConfig.php
@@ -47,9 +47,4 @@ class JsonConfig
 
 		return $this->scanTo($chunks, $this->data);
 	}
-
-	public function getTransifexPrefix()
-	{
-		return $this->getConfigValue('/extra/contao/transifex/prefix');
-	}
 }


### PR DESCRIPTION
I was thinking about arrays and things and in the end I found that there's just too much code to change without knowing where it would have any impacts so I just introduced an optional option for the transifex config param. Default is "transifex" and would thus still work but by using "-t mykey" you can force the toolbox to take the "mkey" instead of "transifex" :)

I was wondering wether we should force to use "transifex-" as prefix...
