### PR TITLE
git log failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ curl -sS https://getcomposer.org/installer | php
 
 2. Install the application.
 ```
-./composer create-project cyberspectrum/contao-toolbox
+php composer create-project --prefer-source cyberspectrum/contao-toolbox
 ```
 
 ### via plain git cloning

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ curl -sS https://getcomposer.org/installer | php
 ```
 php composer create-project --prefer-source cyberspectrum/contao-toolbox
 ```
+**Hint:** At the end of the installation composer will ask you to remove the vcs history:
+
+> Do you want to remove the existing VCS (.git, .svn..) history? [Y,n]?
+
+You must not confirm this question, type `n` to keep the history, otherwise the compiler will not work!
 
 ### via plain git cloning
 ```


### PR DESCRIPTION
When using `php composer.phar create-project cyberspectrum/contao-toolbox` composer will use archive mode by default. In this case, the compile fail, because the git informations are missing in https://github.com/cyberspectrum/contao-toolbox/blob/master/src/CyberSpectrum/Compiler.php#L27

The correct call is `php composer.phar create-project --prefer-source cyberspectrum/contao-toolbox`.
